### PR TITLE
Fix race in OTP extraction on shared install path

### DIFF
--- a/private/escript_wrapper.bzl
+++ b/private/escript_wrapper.bzl
@@ -90,24 +90,71 @@ def _impl(ctx):
 OTP_TAR="$(_resolve '{tar_rloc}' '{tar_exec}')" || \\
     {{ echo>&2 "ERROR: OTP release tar not found (rloc='{tar_rloc}', exec='{tar_exec}')"; exit 1; }}
 OTP_DIR="{install_path}"
-# mkdir(2) is the lock; whoever wins extracts. Same convention as
-# rules_erlang's `maybe_install_erlang`, so the cache is shared with
-# other rules. Portable across GNU and BSD coreutils (no `mv
-# --no-target-directory`, no `find -executable`).
-mkdir -p "$(dirname "${{OTP_DIR}}")"
-if mkdir "${{OTP_DIR}}" 2>/dev/null; then
-    tar --extract --directory "${{OTP_DIR}}" --file "${{OTP_TAR}}"
+OTP_PARENT="$(dirname "${{OTP_DIR}}")"
+OTP_READY="${{OTP_DIR}}/.ready"
+mkdir -p "${{OTP_PARENT}}"
+
+# Install protocol:
+#   1. Each process extracts into a unique sibling tmp dir of OTP_DIR
+#      (same filesystem so rename(2) is atomic).
+#   2. The .ready sentinel is touched inside the tmp dir as the LAST
+#      step, after tar returns successfully.
+#   3. The tmp dir is atomically renamed onto OTP_DIR. The first
+#      winner installs; concurrent losers discard their tmp.
+#   4. Waiters poll for OTP_DIR/.ready. Polling on bin/escript was
+#      unsafe because tar emits bin/ entries before lib/, so escript
+#      could appear long before kernel/stdlib were on disk.
+#
+# Stale recovery: if OTP_DIR exists with no .ready (e.g. left behind
+# by an interrupted run of an older wrapper that did mkdir+tar
+# in-place), take a mkdir-based heal lock, re-check .ready under the
+# lock, then rm -rf and retry. The re-check guarantees we never nuke
+# a fresh install produced by a concurrent extractor.
+#
+# Assumes Linux semantics: rename(2)/`mv -T` returns ENOTEMPTY when
+# the target is a non-empty directory. BSD `mv` lacks `-T` and is
+# not supported here.
+_otp_extract() {{
+    local _tmp
+    _tmp="$(mktemp -d -p "${{OTP_PARENT}}")" || return 1
+    if tar --extract --directory "${{_tmp}}" --file "${{OTP_TAR}}" \\
+        && touch "${{_tmp}}/.ready" \\
+        && mv -T "${{_tmp}}" "${{OTP_DIR}}" 2>/dev/null; then
+        return 0
+    fi
+    rm -rf "${{_tmp}}"
+    return 1
+}}
+
+_otp_wait() {{
+    local _i
+    for _i in $(seq 1 60); do
+        [[ -f "${{OTP_READY}}" ]] && return 0
+        sleep 1
+    done
+    return 1
+}}
+
+if [[ ! -f "${{OTP_READY}}" ]]; then
+    _otp_extract || true
+    if ! _otp_wait; then
+        if mkdir "${{OTP_DIR}}.heal" 2>/dev/null; then
+            if [[ ! -f "${{OTP_READY}}" ]]; then
+                rm -rf "${{OTP_DIR}}"
+            fi
+            rmdir "${{OTP_DIR}}.heal" 2>/dev/null || true
+            _otp_extract || true
+        fi
+        _otp_wait || {{
+            echo>&2 "ERROR: OTP install at ${{OTP_DIR}} is incomplete (no .ready sentinel)."
+            echo>&2 "       Recovery: rm -rf ${{OTP_PARENT}} and retry."
+            exit 1
+        }}
+    fi
 fi
+
 ERLANG_HOME="${{OTP_DIR}}{erlang_home_suffix}"
 ESCRIPT_BIN="${{ERLANG_HOME}}/bin/escript"
-# Wait briefly for a concurrent extractor (lost the mkdir race) to
-# finish writing bin/escript, mirroring `maybe_install_erlang`'s
-# implicit assumption that "directory exists" means "extraction in
-# progress or done".
-for _ in $(seq 1 60); do
-    [[ -x "${{ESCRIPT_BIN}}" ]] && break
-    sleep 1
-done
 [[ -x "${{ESCRIPT_BIN}}" ]] || \\
     {{ echo>&2 "ERROR: ${{ESCRIPT_BIN}} not found or not executable after extraction"; exit 1; }}\
 """.format(

--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -66,9 +66,24 @@ def erlang_dirs(ctx, short_path = False):
 
 def maybe_install_erlang(ctx, short_path = False):
     """Returns shell commands to extract Erlang to the fixed install path.
-    
-    For internal/prebuilt Erlang, this extracts the tar to install_path.
-    The mkdir is used as a lock to ensure only one process extracts.
+
+    For internal/prebuilt Erlang, this extracts the tar to install_path
+    atomically: each caller extracts into a unique sibling tmp dir,
+    touches a `.ready` sentinel after `tar` succeeds, then renames the
+    tmp dir onto install_path. Concurrent losers discard their tmp dir.
+    Waiters poll for the sentinel. A stale install_path with no
+    sentinel (left behind by an interrupted older wrapper) is healed
+    once under a `mkdir` lock.
+
+    Polling on `bin/escript` is not safe because `tar` emits `bin/`
+    before `lib/`, so escript can appear before kernel/stdlib are on
+    disk.
+
+    Linux-only: relies on `mv -T` and rename(2) returning ENOTEMPTY
+    when the target is a non-empty directory.
+
+    Helpers and variables are prefixed `__otp_` to avoid colliding
+    with the caller script's namespace.
     """
     info = _build_info(ctx)
     release_dir_tar = info.release_dir_tar
@@ -76,12 +91,53 @@ def maybe_install_erlang(ctx, short_path = False):
         return ""
     else:
         return """\
-mkdir -p $(dirname "{install_path}")
-if mkdir "{install_path}" 2>/dev/null; then
-    tar --extract \\
-        --directory "{install_path}" \\
-        --file {release_tar}
+__otp_dir="{install_path}"
+__otp_tar="{release_tar}"
+__otp_parent="$(dirname "${{__otp_dir}}")"
+__otp_ready="${{__otp_dir}}/.ready"
+mkdir -p "${{__otp_parent}}"
+
+__otp_extract() {{
+    local _tmp
+    _tmp="$(mktemp -d -p "${{__otp_parent}}")" || return 1
+    if tar --extract --directory "${{_tmp}}" --file "${{__otp_tar}}" \\
+        && touch "${{_tmp}}/.ready" \\
+        && mv -T "${{_tmp}}" "${{__otp_dir}}" 2>/dev/null; then
+        return 0
+    fi
+    rm -rf "${{_tmp}}"
+    return 1
+}}
+
+__otp_wait() {{
+    local _i
+    for _i in $(seq 1 60); do
+        [ -f "${{__otp_ready}}" ] && return 0
+        sleep 1
+    done
+    return 1
+}}
+
+if [ ! -f "${{__otp_ready}}" ]; then
+    __otp_extract || true
+    if ! __otp_wait; then
+        if mkdir "${{__otp_dir}}.heal" 2>/dev/null; then
+            if [ ! -f "${{__otp_ready}}" ]; then
+                rm -rf "${{__otp_dir}}"
+            fi
+            rmdir "${{__otp_dir}}.heal" 2>/dev/null || true
+            __otp_extract || true
+        fi
+        __otp_wait || {{
+            echo>&2 "ERROR: OTP install at ${{__otp_dir}} is incomplete (no .ready sentinel)."
+            echo>&2 "       Recovery: rm -rf ${{__otp_parent}} and retry."
+            exit 1
+        }}
+    fi
 fi
+
+unset -f __otp_extract __otp_wait
+unset __otp_dir __otp_tar __otp_parent __otp_ready
 export ROOTDIR="{install_path}"\
 """.format(
             release_tar = release_dir_tar.short_path if short_path else release_dir_tar.path,


### PR DESCRIPTION
Both maybe_install_erlang (tools/erlang_toolchain.bzl) and the escript worker wrapper (private/escript_wrapper.bzl) extracted the prebuilt OTP tarball into a fixed, shared install path on the host using `mkdir` as a lock. Concurrent processes (multiple Bazel actions, the persistent worker plus a regular action, or leftover state from a previously killed build) could observe a half-extracted install:

  - The mkdir-winner started `tar`, which writes `bin/` entries before `lib/`. Losers either skipped extraction entirely (and proceeded immediately, in maybe_install_erlang) or polled on `bin/escript` (in escript_wrapper) and saw escript long before `kernel` and `stdlib` were on disk.
  - The Erlang VM then booted with an empty code path and died with `{load_failed,[lists,...]}`. In persistent-worker mode this surfaced to Bazel as `IOException: Broken pipe` when the worker exited before reading a WorkRequest.

Replace the mkdir-lock with a write-aside-and-rename protocol:

  1. Each process extracts into a unique sibling tmp dir (`mktemp -d -p $parent`) on the same filesystem.
  2. After `tar` returns successfully, touch a `.ready` sentinel inside the tmp dir.
  3. `mv -T tmp final` atomically promotes the install. Concurrent losers see ENOTEMPTY and `rm -rf` their tmp dir.
  4. Waiters poll for `.ready` (never `bin/escript`).

Stale leftovers (a final dir without `.ready`, e.g. from an interrupted older wrapper that did mkdir + in-place tar) are healed once under a `mkdir`-based heal lock with a re-check, so concurrent extractors cannot nuke a fresh install produced by a peer.

In tools/erlang_toolchain.bzl, helpers and variables are prefixed `__otp_*` and `unset` before `ROOTDIR` is exported, because the snippet is inlined into the caller's shell script.

Linux-only: relies on `mv -T` and rename(2) returning ENOTEMPTY when the target is a non-empty directory. Documented in both files.

Verified end-to-end (rendered Starlark -> bash, against a real tar) for both files across six scenarios: clean install, idempotent re-run, stale-leftover self-heal, 10 concurrent extractions from clean state, 10 concurrent extractions against a stale leftover, and corrupt-tarball failure with no half-baked install left behind.